### PR TITLE
Solves problem of JAR Hell on TCK test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,20 @@
 			<groupId>org.javamoney</groupId>
 			<artifactId>javamoney-tck</artifactId>
 			<version>${org.javamoney.tck.version}</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>moneta-bp</artifactId>
+					<groupId>org.javamoney</groupId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.javamoney.moneta</groupId>
+					<artifactId>moneta-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.javamoney</groupId>
+					<artifactId>moneta-core</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>${impl.groupId}</groupId>
@@ -105,35 +119,16 @@
 			<version>${impl.version}</version>
 			<type>${impl.packageType}</type>
 		</dependency>
-		<!-- 
-		<dependency>
-			<groupId>${impl.groupId}</groupId>
-			<artifactId>moneta-parent</artifactId>
-			<version>${impl.version}</version>
-			<type>${impl.type}</type>
-		</dependency>
-		<dependency>
-			<groupId>${impl.groupId}.moneta</groupId>
-			<artifactId>moneta-core</artifactId>
-			<version>${impl.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>${impl.groupId}.moneta</groupId>
-			<artifactId>moneta-convert</artifactId>
-			<version>${impl.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>${impl.groupId}.moneta</groupId>
-			<artifactId>moneta-convert-ecb</artifactId>
-			<version>${impl.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>${impl.groupId}.moneta</groupId>
-			<artifactId>moneta-convert-imf</artifactId>
-			<version>${impl.version}</version>
-		</dependency>
-		 -->
-		 
+		<!-- <dependency> <groupId>${impl.groupId}</groupId> <artifactId>moneta-parent</artifactId> 
+			<version>${impl.version}</version> <type>${impl.type}</type> </dependency> 
+			<dependency> <groupId>${impl.groupId}.moneta</groupId> <artifactId>moneta-core</artifactId> 
+			<version>${impl.version}</version> </dependency> <dependency> <groupId>${impl.groupId}.moneta</groupId> 
+			<artifactId>moneta-convert</artifactId> <version>${impl.version}</version> 
+			</dependency> <dependency> <groupId>${impl.groupId}.moneta</groupId> <artifactId>moneta-convert-ecb</artifactId> 
+			<version>${impl.version}</version> </dependency> <dependency> <groupId>${impl.groupId}.moneta</groupId> 
+			<artifactId>moneta-convert-imf</artifactId> <version>${impl.version}</version> 
+			</dependency> -->
+
 		<dependency>
 			<groupId>javax.money</groupId>
 			<artifactId>${api.artifactId}</artifactId>


### PR DESCRIPTION
The TCK needs the implementation and back pack implementation to test and compile the project. But the example you need to put your implementation to run the same test, but not more to the RI or  RI-BP.

The problems is, on this way I have some similar dependencies:
- moneta-bp
- Two moneta-core
- The implementation to be tested, the **implementation target**.

![anwser](https://cloud.githubusercontent.com/assets/863011/9504985/12783c04-4c16-11e5-88ec-75ce41f7cc4a.png)

The question is: Imagine we have the some classes that have the same qualifield, the same name and the same path. Which one will be loaded by the JVM? This question, will really difficult to say. This problem with many JARs is normally called of “**JAR Hell**”.

What we need is test my own implementation and not the RI or RI-BP, because it's already tested. Once I want to test a new implementation, I have a duty to provide this new implementation. 
When we put the dependency as “provided” we say the project what will use this project as dependency will provide this dependency. The JSR354-TCK will run normally the dependency will not visible outside the project, something like private on Java but a project instead a class. 

![anwser_02](https://cloud.githubusercontent.com/assets/863011/9505002/2bf60576-4c16-11e5-93af-8447f6a9a387.png)
